### PR TITLE
Add support for PMIC initialization on the new Wandboard rev d1

### DIFF
--- a/board/wandboard/wandboard.c
+++ b/board/wandboard/wandboard.c
@@ -53,6 +53,7 @@ DECLARE_GLOBAL_DATA_PTR;
 #define USDHC1_CD_GPIO		IMX_GPIO_NR(1, 2)
 #define USDHC3_CD_GPIO		IMX_GPIO_NR(3, 9)
 #define ETH_PHY_RESET		IMX_GPIO_NR(3, 29)
+#define ETH_PHY_AR8035_POWER	IMX_GPIO_NR(7, 13)
 #define REV_DETECTION		IMX_GPIO_NR(2, 28)
 
 static bool with_pmic = false;
@@ -107,8 +108,13 @@ static iomux_v3_cfg_t const enet_pads[] = {
 	IOMUX_PADS(PAD_RGMII_RD2__RGMII_RD2  | MUX_PAD_CTRL(ENET_PAD_CTRL)),
 	IOMUX_PADS(PAD_RGMII_RD3__RGMII_RD3  | MUX_PAD_CTRL(ENET_PAD_CTRL)),
 	IOMUX_PADS(PAD_RGMII_RX_CTL__RGMII_RX_CTL | MUX_PAD_CTRL(ENET_PAD_CTRL)),
-	/* AR8031 PHY Reset */
+	/* AR8031/AR8035 PHY Reset */
 	IOMUX_PADS(PAD_EIM_D29__GPIO3_IO29    | MUX_PAD_CTRL(NO_PAD_CTRL)),
+};
+
+static iomux_v3_cfg_t const enet_ar8035_power_pads[] = {
+	/* AR8035 POWER */
+	IOMUX_PADS(PAD_GPIO_18__GPIO7_IO13    | MUX_PAD_CTRL(NO_PAD_CTRL)),
 };
 
 static iomux_v3_cfg_t const rev_detection_pad[] = {
@@ -124,6 +130,13 @@ static void setup_iomux_enet(void)
 {
 	SETUP_IOMUX_PADS(enet_pads);
 
+	if (with_pmic) {
+		SETUP_IOMUX_PADS(enet_ar8035_power_pads);
+		/* enable AR8035 POWER */
+		gpio_direction_output(ETH_PHY_AR8035_POWER, 0);
+	}
+	/* wait until 3.3V of PHY and clock become stable */
+	mdelay(10);
 	/* Reset AR8031/AR8035 PHY */
 	gpio_direction_output(ETH_PHY_RESET, 0);
 	mdelay(10);
@@ -589,7 +602,6 @@ int board_init(void)
 	gd->bd->bi_boot_params = PHYS_SDRAM + 0x100;
 
 	setup_iomux_i2c();
-#endif
 
 	return 0;
 }

--- a/include/configs/wandboard.h
+++ b/include/configs/wandboard.h
@@ -39,9 +39,6 @@
 #define CONFIG_CONS_INDEX		1
 #define CONFIG_BAUDRATE			115200
 
-/* Command definition */
-#include <config_cmd_default.h>
-
 #define CONFIG_CMD_SATA
 #ifdef CONFIG_CMD_SATA
 #define CONFIG_DWC_AHSATA
@@ -54,9 +51,6 @@
 
 /* Command definition */
 #define CONFIG_CMD_BMODE
-#define CONFIG_CMD_SETEXPR
-
-#define CONFIG_BOOTDELAY		1
 
 #define CONFIG_SYS_MEMTEST_START	0x10000000
 #define CONFIG_SYS_MEMTEST_END		(CONFIG_SYS_MEMTEST_START + 500 * SZ_1M)
@@ -138,14 +132,16 @@
 			"fi; "	\
 		"fi\0" \
 	"findfdt="\
+		"if test $board_name = D1 && test $board_rev = MX6QP ; then " \
+			"setenv fdtfile imx6qp-wandboard-revd1.dtb; fi; " \
 		"if test $board_name = D1 && test $board_rev = MX6Q ; then " \
 			"setenv fdtfile imx6q-wandboard-revd1.dtb; fi; " \
 		"if test $board_name = D1 && test $board_rev = MX6DL ; then " \
 			"setenv fdtfile imx6dl-wandboard-revd1.dtb; fi; " \
 		"if test $board_name = C1 && test $board_rev = MX6Q ; then " \
-			"setenv fdtfile imx6q-wandboard.dtb; fi; " \
+			"setenv fdtfile imx6q-wandboard-revc1.dtb; fi; " \
 		"if test $board_name = C1 && test $board_rev = MX6DL ; then " \
-			"setenv fdtfile imx6dl-wandboard.dtb; fi; " \
+			"setenv fdtfile imx6dl-wandboard-revc1.dtb; fi; " \
 		"if test $board_name = B1 && test $board_rev = MX6Q ; then " \
 			"setenv fdtfile imx6q-wandboard-revb1.dtb; fi; " \
 		"if test $board_name = B1 && test $board_rev = MX6DL ; then " \

--- a/include/configs/wandboard.h
+++ b/include/configs/wandboard.h
@@ -17,6 +17,14 @@
 #define MACH_TYPE_WANDBOARD		4412
 #define CONFIG_MACH_TYPE		MACH_TYPE_WANDBOARD
 
+#define CONFIG_CMDLINE_TAG
+#define CONFIG_SETUP_MEMORY_TAGS
+#define CONFIG_INITRD_TAG
+#define CONFIG_REVISION_TAG
+
+#define CONFIG_SYS_GENERIC_BOARD
+#undef CONFIG_LDO_BYPASS_CHECK
+
 /* Size of malloc() pool */
 #define CONFIG_SYS_MALLOC_LEN		(10 * SZ_1M)
 
@@ -27,6 +35,12 @@
 #define CONFIG_MXC_UART_BASE		UART1_BASE
 
 /* SATA Configs */
+#define CONFIG_ENV_OVERWRITE
+#define CONFIG_CONS_INDEX		1
+#define CONFIG_BAUDRATE			115200
+
+/* Command definition */
+#include <config_cmd_default.h>
 
 #define CONFIG_CMD_SATA
 #ifdef CONFIG_CMD_SATA
@@ -40,6 +54,9 @@
 
 /* Command definition */
 #define CONFIG_CMD_BMODE
+#define CONFIG_CMD_SETEXPR
+
+#define CONFIG_BOOTDELAY		1
 
 #define CONFIG_SYS_MEMTEST_START	0x10000000
 #define CONFIG_SYS_MEMTEST_END		(CONFIG_SYS_MEMTEST_START + 500 * SZ_1M)
@@ -51,6 +68,13 @@
 #define CONFIG_SYS_I2C_MXC_I2C2		/* enable I2C bus 2 */
 #define CONFIG_SYS_I2C_MXC_I2C3		/* enable I2C bus 3 */
 #define CONFIG_SYS_I2C_SPEED		100000
+#define CONFIG_I2C_PMIC			2
+
+/* PMIC */
+#define CONFIG_POWER
+#define CONFIG_POWER_I2C
+#define CONFIG_POWER_PFUZE100
+#define CONFIG_POWER_PFUZE100_I2C_ADDR	0x08
 
 /* MMC Configuration */
 #define CONFIG_SYS_FSL_USDHC_NUM	2
@@ -114,6 +138,10 @@
 			"fi; "	\
 		"fi\0" \
 	"findfdt="\
+		"if test $board_name = D1 && test $board_rev = MX6Q ; then " \
+			"setenv fdtfile imx6q-wandboard-revd1.dtb; fi; " \
+		"if test $board_name = D1 && test $board_rev = MX6DL ; then " \
+			"setenv fdtfile imx6dl-wandboard-revd1.dtb; fi; " \
 		"if test $board_name = C1 && test $board_rev = MX6Q ; then " \
 			"setenv fdtfile imx6q-wandboard.dtb; fi; " \
 		"if test $board_name = C1 && test $board_rev = MX6DL ; then " \
@@ -156,6 +184,9 @@
 	(CONFIG_SYS_INIT_RAM_SIZE - GENERATED_GBL_DATA_SIZE)
 #define CONFIG_SYS_INIT_SP_ADDR \
 	(CONFIG_SYS_INIT_RAM_ADDR + CONFIG_SYS_INIT_SP_OFFSET)
+
+/* FLASH and environment organization */
+#define CONFIG_SYS_NO_FLASH
 
 /* Environment organization */
 #define CONFIG_ENV_SIZE			(8 * 1024)


### PR DESCRIPTION
The new Wandboard has a PMIC which starts with the Ethernet PHY off. This patch (extracted from the wandboard official u-boot fork) add support for this new revision.